### PR TITLE
Fixes issues with limited DAQ functionality

### DIFF
--- a/Acquisition/Poll/source/poll2.cpp
+++ b/Acquisition/Poll/source/poll2.cpp
@@ -71,7 +71,7 @@ int main(int argc, char *argv[]) {
     int retval = 0;
 
     // Read the FIFO when it is this full
-    int fifoThresholdReadPercentage = 50;
+    double fifoThresholdReadPercentage = 50.;
     std::string alarmArgument = "";
     bool usePixieInterface = true;
     const char* configurationFile = "./pixie-cfg.xml";
@@ -96,7 +96,7 @@ int main(int argc, char *argv[]) {
                 poll.SetQuietMode(false);
                 break;
             case 't' :
-                fifoThresholdReadPercentage = std::stoi(optarg);
+                fifoThresholdReadPercentage = std::stod(optarg);
                 if (fifoThresholdReadPercentage <= 0) {
                     std::cerr << Display::ErrorStr() << " Failed to set threshold level to ("
                               << fifoThresholdReadPercentage << ")!\n";

--- a/Acquisition/Poll/source/poll2_core.cpp
+++ b/Acquisition/Poll/source/poll2_core.cpp
@@ -48,11 +48,15 @@
 std::vector<std::string> chan_params = {"TRIGGER_RISETIME", "TRIGGER_FLATTOP", "TRIGGER_THRESHOLD", "ENERGY_RISETIME",
                                         "ENERGY_FLATTOP", "TAU", "TRACE_LENGTH", "TRACE_DELAY", "VOFFSET", "XDT",
                                         "BASELINE_PERCENT", "EMIN", "BINFACTOR", "CHANNEL_CSRA", "CHANNEL_CSRB", "BLCUT",
-                                        "ExternDelayLen", "ExtTrigStretch", "ChanTrigStretch", "FtrigoutDelay", "FASTTRIGBACKLEN"};
+                                        "ExternDelayLen", "ExtTrigStretch", "ChanTrigStretch", "FtrigoutDelay",
+                                        "FASTTRIGBACKLEN", "CFDDelay", "CFDScale", "CFDThresh", "QDCLen0", "QDCLen1",
+                                        "QDCLen2", "QDCLen3", "QDCLen4", "QDCLen5", "QDCLen6", "QDCLen7", "VetoStretch",
+                                        "MultiplicityMaskL", "MultiplicityMaskH"};
 
 std::vector<std::string> mod_params = {"MODULE_CSRA", "MODULE_CSRB", "MODULE_FORMAT", "MAX_EVENTS", "SYNCH_WAIT", "IN_SYNCH",
-                                       "SLOW_FILTER_RANGE", "FAST_FILTER_RANGE", "MODULE_NUMBER", "TrigConfig0", "TrigConfig1",
-                                       "TrigConfig2","TrigConfig3"};
+                                       "SLOW_FILTER_RANGE", "FAST_FILTER_RANGE", "ModuleID", "TrigConfig0",
+                                       "TrigConfig1", "TrigConfig2","TrigConfig3", "FastTrigBackplaneEna", "CrateID",
+                                       "SlotID", "HOST_RT_PRESET"};
 
 const std::vector<std::string> Poll::runControlCommands_ ({"run", "stop", "startacq", "startvme", "stopacq", "stopvme",
                                                            "timedrun", "shm", "spill", "hup", "prefix", "fdir",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
### Command lists
Poll2 didn't allow users full access to Pixie16 Module/Channel parameters. I added all missing parameters by comparing the parameter lists with the API. 

### FIFO Threshold
Users couldn't set a FIFO threshold < 1% from command line. Ended up being due to a parameter type mismatch. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#227 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Users wanted full access to the parameters because they needed to set multiplicity masks. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I manually tested that all of the commands were recognized from p(m)read/p(m)write. I couldn't test against modules. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contributing](https://github.com/spaulaus/paass-laughing-conqueror/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
