### PR TITLE
Resolving Issue with bad trace lengths 

### DIFF
--- a/Acquisition/Poll/source/poll2_core.cpp
+++ b/Acquisition/Poll/source/poll2_core.cpp
@@ -60,12 +60,18 @@
 // Maximum shm packet size (in bytes)
 #define MAX_PKT_DATA (MAX_ORPH_DATA - PKT_HEAD_LEN)
 
-std::vector<std::string> chan_params = {"TRIGGER_RISETIME", "TRIGGER_FLATTOP", "TRIGGER_THRESHOLD", "ENERGY_RISETIME", "ENERGY_FLATTOP", "TAU", "TRACE_LENGTH",
-                                        "TRACE_DELAY", "VOFFSET", "XDT", "BASELINE_PERCENT", "EMIN", "BINFACTOR", "CHANNEL_CSRA", "CHANNEL_CSRB", "BLCUT",
-                                        "ExternDelayLen", "ExtTrigStretch", "ChanTrigStretch", "FtrigoutDelay", "FASTTRIGBACKLEN"};
+std::vector<std::string> chan_params = {"TRIGGER_RISETIME", "TRIGGER_FLATTOP", "TRIGGER_THRESHOLD", "ENERGY_RISETIME",
+                                        "ENERGY_FLATTOP", "TAU", "TRACE_LENGTH", "TRACE_DELAY", "VOFFSET", "XDT",
+                                        "BASELINE_PERCENT", "EMIN", "BINFACTOR", "CHANNEL_CSRA", "CHANNEL_CSRB", "BLCUT",
+                                        "ExternDelayLen", "ExtTrigStretch", "ChanTrigStretch", "FtrigoutDelay",
+                                        "FASTTRIGBACKLEN", "CFDDelay", "CFDScale", "CFDThresh", "QDCLen0", "QDCLen1",
+                                        "QDCLen2", "QDCLen3", "QDCLen4", "QDCLen5", "QDCLen6", "QDCLen7", "VetoStretch",
+                                        "MultiplicityMaskL", "MultiplicityMaskH"};
 
-std::vector<std::string> mod_params = {"MODULE_CSRA", "MODULE_CSRB", "MODULE_FORMAT", "MAX_EVENTS", "SYNCH_WAIT", "IN_SYNCH", "SLOW_FILTER_RANGE",
-                                       "FAST_FILTER_RANGE", "MODULE_NUMBER", "TrigConfig0", "TrigConfig1", "TrigConfig2","TrigConfig3"};
+std::vector<std::string> mod_params = {"MODULE_CSRA", "MODULE_CSRB", "MODULE_FORMAT", "MAX_EVENTS", "SYNCH_WAIT", "IN_SYNCH",
+                                       "SLOW_FILTER_RANGE", "FAST_FILTER_RANGE", "ModuleID", "TrigConfig0",
+                                       "TrigConfig1", "TrigConfig2","TrigConfig3", "FastTrigBackplaneEna", "CrateID",
+                                       "SlotID", "HOST_RT_PRESET"};
 
 const std::vector<std::string> Poll::runControlCommands_ ({"run", "stop",
                                                            "startacq", "startvme", "stopacq", "stopvme", "timedrun", "acq", "shm", "spill",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
I added a catch that finds any trace lengths with a value of 32767 and sets them to 0. The root cause of this seems to come from the data, but I need to confirm this with XIA. This resolves the issue and users are able to scan data properly. 
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#247 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Users couldn't scan data and buffers were going missing. 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested this against LDFs and PLDs. The fix seems to be stable. No additional unit tests added. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contributing](https://github.com/spaulaus/paass-laughing-conqueror/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
